### PR TITLE
changed reason_reference to List[str] and removed custom resolver

### DIFF
--- a/api/schemas/katsu/mcode/cancer_related_procedure.py
+++ b/api/schemas/katsu/mcode/cancer_related_procedure.py
@@ -25,7 +25,7 @@ class CancerRelatedProcedure:
     laterality: Optional[Ontology] = None
     treatment_intent: Optional[Ontology] = None
     reason_code: Optional[Ontology] = None
-    reason_reference: Optional[List[CancerCondition]] = None
+    reason_reference: Optional[List[str]] = None # reason_reference is a list of ids (represented as strings) to cancer conditions
     extra_properties: Optional[JSONScalar] = None
     created: Optional[str] = None
     updated: Optional[str] = None
@@ -38,7 +38,6 @@ class CancerRelatedProcedure:
                                     ("treatment_intent", Ontology), ("reason_code", Ontology)]:
             set_field(json, ret, field_name, type)
         set_field_list(json, ret, "body_site", Ontology)
-        set_field_list(json, ret, "reason_reference", CancerCondition)
         set_extra_properties(json, ret)
         return ret
     


### PR DESCRIPTION
Small PR to resolve a bug regarding reason_reference. reason_reference is a list of ids to cancer conditions [as per the FHIR specification](https://www.hl7.org/fhir/extension-workflow-reasonreference.html). This is now reflected in the strawberry schema of the CancerCondition type.