### PR TITLE
GraphQL-interface Error Corrections - CanDIG & Katsu Schemas

### DIFF
--- a/api/schemas/candig_server/variant.py
+++ b/api/schemas/candig_server/variant.py
@@ -4,6 +4,7 @@ from api.schemas.dataloader_input import DataLoaderInput
 from api.schemas.utils import get_candig_server_response, get_post_search_body, get_post_variant_search_body, get_token, post_candig_server_response
 from typing import List, Optional
 import strawberry
+from api.schemas.scalars.json_scalar import JSONScalar
 """
 CanDIG server variants dataloader function
 """
@@ -47,6 +48,7 @@ class CandigServerVariantInput:
 class CandigServerVariant:
     id: Optional[strawberry.ID] = None
     variantSetId: Optional[strawberry.ID] = None
+    names: Optional[List[str]] = None
     referenceName: Optional[str] = None
     start: Optional[str] = None
     end: Optional[str] = None
@@ -54,12 +56,13 @@ class CandigServerVariant:
     alternateBases: Optional[List[str]] = None
     filtersApplied: Optional[bool] = None
     filtersPassed: Optional[bool] = None
+    attributes: Optional[JSONScalar] = None
 
     @strawberry.field
     async def get_katsu_individuals(self, info) -> Optional[Individual]:
         token = get_token(info)
         patient_id = self.get_patient_id()
-        res = await info.context["individuals_loader"].load(DataLoaderInput(token, patient_id))
+        res = await info.context["individuals_loader"].load(DataLoaderInput(token, [patient_id]))
         ind = None
         for x in res.output:
             if x["id"] == patient_id:

--- a/api/schemas/dataloader_input.py
+++ b/api/schemas/dataloader_input.py
@@ -1,5 +1,5 @@
 class DataLoaderInput:
-    def __init__(self, token, ids, page_number):
+    def __init__(self, token, ids=None, page_number=None):
         self.token = token
         if page_number == None:
             self.page_number = 1

--- a/api/schemas/katsu/mcode/cancer_genetic_variant.py
+++ b/api/schemas/katsu/mcode/cancer_genetic_variant.py
@@ -28,7 +28,7 @@ class CancerGeneticVariant:
     amino_acid_change_type: Optional[Ontology] = None
     cytogenetic_location: Optional[Ontology] = None
     cytogenetic_nomenclature: Optional[Ontology] = None
-    gene_studied: Optional[Gene] = None
+    gene_studied: Optional[List[Gene]] = None
     genomic_dna_change: Optional[Ontology] = None
     genomic_source_class: Optional[Ontology] = None
     variation_code: Optional[List[Ontology]] = None
@@ -43,13 +43,13 @@ class CancerGeneticVariant:
         for (field_name, type) in [("data_value", Ontology), ("method", Ontology),\
                                     ("amino_acid_change", Ontology), ("amino_acid_change_type", Ontology),\
                                     ("cytogenetic_location", Ontology), ("cytogenetic_nomenclature", Ontology),\
-                                    ("gene_studied", Gene), ("genomic_dna_change", Ontology),\
-                                    ("genomic_source_class", Ontology)]:
+                                    ("genomic_dna_change", Ontology), ("genomic_source_class", Ontology)]:
             set_field(json, ret, field_name, type)
         if isinstance(json["variation_code"], List):
             set_field_list(json, ret, "variation_code", Ontology)
         else:
             set_field(json, ret, "variation_code", Ontology)
+        set_field_list(json, ret, "gene_studied", Gene)
         set_extra_properties(json, ret)
         
         return ret

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+wheel==0.37.1
 strawberry-graphql>=0.73.4
-starlette
-uvicorn
-requests
-websockets
-fastapi
+starlette==0.17.1
+uvicorn==0.16.0
+requests==2.27.1
+websockets==10.1
+fastapi==0.71.0


### PR DESCRIPTION
### Description
This PR is for several fixes to the GraphQL-interface Schemas to fix errors in collecting data from Katsu and from the CanDIG server. When testing the Katsu server for [DIG-757 Ticket](https://candig.atlassian.net/browse/DIG-757), the GraphQL endpoint would error out because of missing fields and similarly when testing the GraphQL endpoint for the CanDIG server [(DIG-769 Ticket)](https://candig.atlassian.net/browse/DIG-769), the endpoint would error because of missing data fields. The errors were traced to incorrect deserialization and missing Schema parameters. These changes address those errors. 

This PR also addresses some dependency issues that arise when working with this repository. Recent updates to packages like starlette break the fastapi implementation used in this library, and hence, I have added static library versions to counteract this.

### Changelog
- Fixing CanDIG Variant Schemas to properly deserialize CandigServerVariant objects 
- Fixing DataLoader Class __init__ method to accept empty ids and page_number parameters to allow for CanDIG Variant Data to be properly extracted
- Fixing Katsu Schema to properly deserialize Cancer Genetic Information and accept a List of Genes, instead of a single Gene
- Introducing Static Library dependencies to ensure GraphQL implementation doesn't break with new module releases

### Dependencies
- None

### Testing
(Borrowed from [this comment](https://github.com/CanDIG/GraphQL-interface/pull/6#issuecomment-1026236962)). I also built a README for setup but that's for the DIG-779/DIG-780 PRs so they'll come in handy later on.

**Katsu Setup** (Borrowed from README for federated-learning Repo):
- Clone Federated-Learning Repo
- Install Dependencies: 
    - **Clone CanDIG/Katsu** The current release of CanDIG/Katsu does not support MCODE data, so you will have to supply a locally built Docker image of CanDIG/Katsu. Clone the [Katsu repository](https://github.com/CanDIG/katsu) to prepare the build context.  
        - Note that the current Katsu build may be incompatible with the federated-learning repo and so you might have to do `git checkout a321c235d52b615aef2cf97393eb20214bed6707` within the `katsu` root directory.
    - **Pull submodule updates.** 
        - The `katsu` repository relies on `DATS JSON` schemas. Pull this dependency by navigating to the `katsu` repo and run `git submodule update --init`
        - The `federated-learning` repository relies on the `mohccn-data` submodule to provide adequate synthetic data for training purposes. Pull this dependency by navigating to the `federated-learning` repo and run `git submodule update --init`
- Start Katsu:
    - **Configure docker-compose.** The `docker-compose.yaml` file expects a `.env` file in root federated-learning folder, so that it can configure the Katsu database with some secrets such as the password. 
        - For a generic configuration, you can run the following to copy and use the default configuration within the federated-learning root directory: `cp .default.env .env`.
        - Configure `KATSU_DIR` in your .env file to point to the `katsu` repo on your machine.
        - If you want to access katsu from another machine on your local network, you will need to change the list of allowed hosts within katsu: 
            - Open the `katsu/chord_metadata_service/metadata/settings.py` file 
            - Change the `ALLOWED_HOSTS` variable to be equal to `["*"]` instead of `[CHORD_HOST or "localhost"]`
    - **Spin up Katsu.** Within the federated-learning root repository, run `docker-compose up katsu`
    - **Browse Katsu.** Navigate your browser to `localhost:8000`
    - **Query Katsu** by GETting from `localhost:8000/api/mcodepackets`. There will be zero results (`"count": 0`) prior to ingest, and a number of results equal to the dataset size following ingest. 
- Ingesting Synthea Data:
    - The dataset currently being used for training can be browsed [here](https://confluence.hl7.org/display/COD/mCODE+Test+Data) under `Approx. 2,000 Patient Records with 10 Years of Medical History`. Or, just click this direct download [link](http://hdx.mitre.org/downloads/mcode/mcode1_0_10yrs.zip).
    - Once downloaded, unzip the folder and move the `10yrs` subdirectory into the `federated-learning` project root, or wherever you prefer.
    - Ensure you are in the root federated-learning repository. Then the following command will allow you to ingest all files in the local `10yrs` directory as `mcodepackets` into the `test_project/dataset/table`. 
```
cp 10yrs/female/* 10yrs/male/* 10yrs/assorted/* 10yrs
rm -r 10yrs/female 10yrs/male 10yrs/assorted
./ingestion_scripts/init.sh -l -d 10yrs test_proj test_dataset test_table mcodepacket
```
___
**GraphQL Setup** (Borrowed from README for GraphQL-interface repo):
- Clone this branch of the GraphQL-interface Repo
- Setup Local Environment:
    - In the root GraphQL-interface directory, run: `export KATSU_API=http://localhost:8000/api`
    - Build a virtualenv for the repo within the root GraphQL-interface directory: `python3 -m venv venv`
    - Activate Virtual Environment: `source venv/bin/activate`
    - Install the requirements 
``` 
pip install -r requirements.txt 
pip install pandas sklearn
```
   - Run the GraphQL interface: 
``` 
uvicorn app:app --reload --host 0.0.0.0 --port 7999 
```

Now go to http://localhost:8000/api/mcodepackets and from the first result in the `results` array, get the id field, noting it down.

Now, when you try going to the GraphiQL service at port 7999/graphql, you will see a dashboard where you can input your queries on the left-hand side and the response will show up on the right. Enter the following query into the left-hand side. Replace "yourCollectedId" with the value of the ID, keeping it as a string:
```
query{
  katsuDataModels
  {
    mcodeDataModels
    {
      mcodePackets(input: {ids: ["yourcollectedID"]}){
        id
        subject {
          dateOfBirth
        }
        cancerCondition {
          dateOfDiagnosis
          tnmStaging{
            primaryTumorCategory{
              dataValue{
                label
              }
            }
          }
        }
      }
      genomicsReports{
        id
      }
    }
  }
}
```

You should see the genomicsReports section giving you `[]` instead of erroring out.