### PR TITLE
DIG-799: Updated Schema to fix errors in Integration Testing

### DIFF
--- a/api/query.py
+++ b/api/query.py
@@ -18,7 +18,10 @@ class Query:
 
     @strawberry.field
     async def candig_server_variants(self, info, input: Optional[CandigServerVariantInput], dataset_name: Optional[str] = None, dataset_id: Optional[str] = None) -> List[CandigServerVariant]:
-        return await info.context["candig_server_variants_loader"].load(CandigServerVariantDataLoaderInput(None, input, None, info))
+        dataset_ids = (dataset_id,) if dataset_id is not None else None
+        patient = input.katsu_individual if input is not None  else None
+        patient_id = patient.ids if patient is not None else None
+        return await info.context["candig_server_variants_loader"].load(CandigServerVariantDataLoaderInput(dataset_ids, input, patient_id, info))
 
     @strawberry.field
     async def aggregate(self, info) -> AggregateQuery:

--- a/api/schemas/beacon/beacon_data_models.py
+++ b/api/schemas/beacon/beacon_data_models.py
@@ -226,8 +226,9 @@ class BeaconAlleleResponse:
     
     ''' get_request_info(): Get input specs requested by the user'''
     def get_request_info(self) -> Tuple[int, int, str, str, str, Optional[List[str]]]: 
+        datasets = tuple(self.alleleRequest.datasetIds) if self.alleleRequest.datasetIds is not None else None
         return self.alleleRequest.start, self.alleleRequest.end, self.alleleRequest.referenceName, \
-            self.alleleRequest.referenceBases, self.alleleRequest.alternateBases, self.alleleRequest.datasetIds
+            self.alleleRequest.referenceBases, self.alleleRequest.alternateBases, datasets
     
     '''get_individuals(): Get BeaconIndividuals matching input specs'''
     async def get_individuals(self, info) -> List[BeaconIndividual]:
@@ -295,7 +296,8 @@ async def get_beacon_alleles(param):
 
 '''collect_input_fields(input): Collect cleaned input data from user request'''
 def collect_input_fields(input: BeaconAlleleRequest) -> Tuple[str, str, str, str, str, Optional[List[str]]]:
-    return str(input.start), str(input.end), input.referenceName, input.referenceBases, input.alternateBases, input.datasetIds
+    datasets = tuple(input.datasetIds) if input.datasetIds is not None else None
+    return str(input.start), str(input.end), input.referenceName, input.referenceBases, input.alternateBases, datasets
 
 
 ''' variant_matches(variant, start, end, name, base, alt_base): Check if the variant matches given input fields'''

--- a/api/schemas/json_formats/age_or_age_range.py
+++ b/api/schemas/json_formats/age_or_age_range.py
@@ -1,5 +1,6 @@
 from api.interfaces.input import Input
 from typing import Optional
+from api.schemas.utils import set_field
 import strawberry
 
 @strawberry.input
@@ -9,18 +10,30 @@ class AgeInputType(Input):
     end: Optional[int] = None
 
 @strawberry.type
-class AgeRange:
-    start: str
-    end: str
+class Age:
+    age: str
+
+    @staticmethod
+    def deserialize(json):
+        return Age(**json)
 
     @staticmethod
     def filter(instance, input: AgeInputType):
         return filter_age(instance, input)
 
-
 @strawberry.type
-class Age:
-    age: str
+class AgeRange:
+    start: Age
+    end: Age
+
+    @staticmethod
+    def deserialize(json):
+        ret = AgeRange(**json)
+
+        set_field(json, ret, 'start', Age)
+        set_field(json, ret, 'end', Age)
+
+        return ret
 
     @staticmethod
     def filter(instance, input: AgeInputType):

--- a/api/schemas/json_formats/phenopacket_evidence.py
+++ b/api/schemas/json_formats/phenopacket_evidence.py
@@ -1,20 +1,28 @@
+from api.schemas.json_formats.phenopacket_external_reference import PhenopacketExternalReference, PhenopacketExternalReferenceInputType
+from api.schemas.json_formats.ontology import Ontology, OntologyInputType
 from api.interfaces.input import Input
-from api.schemas.utils import generic_filter
+from api.schemas.utils import generic_filter, set_field
 from typing import Optional
 import strawberry
-from .ontology import Ontology, OntologyInputType
 
 @strawberry.input
 class PhenopacketEvidenceInputType(Input):
     evidence_code: Optional[OntologyInputType] = None
+    reference: Optional[PhenopacketExternalReferenceInputType] = None
 
 @strawberry.type
 class PhenopacketEvidence:
     evidence_code: Ontology
+    reference: Optional[PhenopacketExternalReference] = None
     
     @staticmethod
     def deserialize(json):
-        return PhenopacketEvidence(**json)
+        ret = PhenopacketEvidence(**json)
+
+        for (field_name ,type) in [("evidence_code", Ontology), ("reference", PhenopacketExternalReference)]:
+            set_field(json, ret, field_name, type)
+
+        return ret
     
     @staticmethod
     def filter(instance, input: PhenopacketEvidenceInputType):

--- a/api/schemas/json_formats/phenopacket_external_reference.py
+++ b/api/schemas/json_formats/phenopacket_external_reference.py
@@ -1,4 +1,3 @@
-
 from api.interfaces.input import Input
 from api.schemas.utils import generic_filter
 from typing import Optional
@@ -13,7 +12,7 @@ class PhenopacketExternalReferenceInputType(Input):
 @strawberry.type
 class PhenopacketExternalReference:
     id: str
-    description: str
+    description: Optional[str] = None
 
     @staticmethod
     def deserialize(json):

--- a/api/schemas/json_formats/ratio.py
+++ b/api/schemas/json_formats/ratio.py
@@ -1,4 +1,4 @@
-from api.schemas.utils import generic_filter
+from api.schemas.utils import generic_filter, set_field
 from api.schemas.json_formats.quantity import Quantity, QuantityInputType
 from typing import Optional
 import strawberry
@@ -15,7 +15,10 @@ class Ratio:
 
     @staticmethod
     def deserialize(json):
-        return Ratio(**json)
+        ret = Ratio(**json)
+        set_field(json, ret, "numerator", Quantity)
+        set_field(json, ret, "denominator", Quantity)
+        return ret
 
     @staticmethod
     def filter(instance, input: RatioInputType):

--- a/api/schemas/katsu/mcode/genomics_report.py
+++ b/api/schemas/katsu/mcode/genomics_report.py
@@ -35,8 +35,7 @@ class GenomicsReport:
         ret = GenomicsReport(**json)
 
         for (field_name, type) in [
-            ("code", Ontology), ("performing_orgization_name", Ontology), 
-            ("genetic_variant", CancerGeneticVariant), ("genomic_region_studied", GenomicRegionStudied)]:
+            ("code", Ontology), ("genetic_variant", CancerGeneticVariant), ("genomic_region_studied", GenomicRegionStudied)]:
             set_field(json, ret, field_name, type)
         set_field_list(json, ret, "genetic_specimen", GeneticSpecimen)
         set_extra_properties(json, ret)

--- a/api/schemas/katsu/mcode/labs_vital.py
+++ b/api/schemas/katsu/mcode/labs_vital.py
@@ -3,7 +3,6 @@ from api.schemas.scalars.json_scalar import JSONScalar
 from api.schemas.json_formats.ratio import Ratio, RatioInputType
 from api.schemas.json_formats.quantity import Quantity, QuantityInputType
 from api.schemas.utils import generic_filter, set_extra_properties, set_field
-from api.schemas.katsu.phenopacket.individual import Individual, IndividualInputType
 from typing import List, Optional, Union
 import strawberry
 from api.schemas.json_formats.ontology import Ontology, OntologyInputType
@@ -11,7 +10,7 @@ from api.schemas.json_formats.ontology import Ontology, OntologyInputType
 @strawberry.input
 class LabsVitalInputType(Input):
     ids: Optional[List[strawberry.ID]]= None
-    individual: Optional[IndividualInputType] = None
+    individual: Optional[str] = None
     tumor_marker_code: Optional[OntologyInputType] = None
     tumor_marker_data_value_ratio: Optional[RatioInputType] = None
     tumor_marker_data_value_quantity: Optional[QuantityInputType] = None
@@ -20,7 +19,7 @@ class LabsVitalInputType(Input):
 @strawberry.type
 class LabsVital:
     id: Optional[strawberry.ID] = None
-    individual: Optional[Individual] = None
+    individual: Optional[str] = None
     tumor_marker_code: Optional[Ontology] = None
     tumor_marker_data_value: Optional[Union[Quantity, Ratio, Ontology]] = None #TUMOR_MARKER_DATA_VALUE in katsu json schemas
     extra_properties: Optional[JSONScalar] = None
@@ -31,7 +30,7 @@ class LabsVital:
     def deserialize(json):
         ret = LabsVital(**json)
 
-        for (field_name, type) in [("individual", Individual), ("tumor_marker_code", Ontology)]:
+        for (field_name, type) in [("tumor_marker_code", Ontology)]:
             set_field(json, ret, field_name, type)
 
         if ret.tumor_marker_data_value:

--- a/api/schemas/katsu/mcode/mcode_data_models.py
+++ b/api/schemas/katsu/mcode/mcode_data_models.py
@@ -20,7 +20,7 @@ class McodeDataModels:
 
     @strawberry.field
     async def genomic_regions_studied(self, info, input: Optional[GenomicRegionStudiedInputType] = None) -> List[GenomicRegionStudied]:
-        return await generic_resolver(info, "mcode_genomic_regions_studied_loader", input, GenomicsReport)
+        return await generic_resolver(info, "mcode_genomic_regions_studied_loader", input, GenomicRegionStudied)
 
     @strawberry.field
     async def genomics_reports(self, info, input: Optional[GenomicsReportInputType] = None) -> List[GenomicsReport]:

--- a/api/schemas/katsu/mcode/tnm_staging.py
+++ b/api/schemas/katsu/mcode/tnm_staging.py
@@ -1,5 +1,4 @@
 from api.interfaces.input import Input
-from api.schemas.katsu.mcode.cancer_condition import CancerCondition, CancerConditionInputType
 from api.schemas.utils import generic_filter, set_extra_properties, set_field
 from api.schemas.scalars.json_scalar import JSONScalar
 from api.schemas.json_formats.complex_ontology import ComplexOntology, ComplexOntologyInputType
@@ -14,7 +13,7 @@ class TNMStagingInputType(Input):
     primary_tumor_category: Optional[ComplexOntologyInputType] = None
     regional_nodes_category: Optional[ComplexOntologyInputType] = None
     distant_metastases_category: Optional[ComplexOntologyInputType] = None
-    cancer_condition: Optional[CancerConditionInputType] = None
+    cancer_condition: Optional[str] = None
 
 @strawberry.type
 class TNMStaging:
@@ -24,7 +23,7 @@ class TNMStaging:
     primary_tumor_category: Optional[ComplexOntology] = None
     regional_nodes_category: Optional[ComplexOntology] = None
     distant_metastases_category: Optional[ComplexOntology] = None
-    cancer_condition: Optional[CancerCondition] = None
+    cancer_condition: Optional[str] = None
     extra_properties: Optional[JSONScalar] = None
     created: Optional[str] = None
     updated: Optional[str] = None
@@ -34,8 +33,7 @@ class TNMStaging:
     def deserialize(json):
         ret = TNMStaging(**json)
         for (field_name, type) in [("stage_group", ComplexOntology), ("primary_tumor_category", ComplexOntology),\
-                                    ("regional_nodes_category", ComplexOntology), ("distant_metastases_category", ComplexOntology),\
-                                    ("cancer_condition", CancerCondition)]:
+                                    ("regional_nodes_category", ComplexOntology), ("distant_metastases_category", ComplexOntology)]:
             set_field(json, ret, field_name, type)
         set_extra_properties(json, ret)
         return ret

--- a/api/schemas/katsu/phenopacket/biosample.py
+++ b/api/schemas/katsu/phenopacket/biosample.py
@@ -42,7 +42,7 @@ class Biosample:
     histological_diagnosis: Optional[Ontology] = None
     tumor_progression: Optional[Ontology] = None
     tumor_grade: Optional[Ontology] = None
-    diagnostic_markers: Optional[Ontology] = None
+    diagnostic_markers: Optional[List[Ontology]] = None
     procedure: Optional[Procedure] = None
     hts_files: Optional[List[str]] = None
     variants: Optional[List[Variant]] = None
@@ -55,20 +55,19 @@ class Biosample:
     def deserialize(json):
         ret = Biosample(**json)
         
-        for (field_name, type) in [("phenotypic_features", PhenotypicFeature), ("variants", Variant)]:
+        for (field_name, type) in [("phenotypic_features", PhenotypicFeature), ("variants", Variant), ("diagnostic_markers", Ontology)]:
             set_field_list(json, ret, field_name, type)
 
         for (field_name, type) in [("sampled_tissue", SampleTissue), ("taxonomy", Ontology), ("histological_diagnosis", Ontology),
-                                    ("tumor_progression", Ontology), ("tumor_grade", Ontology), ("diagnostic_markers", Ontology),
-                                    ("procedure", Procedure)]:
+                                    ("tumor_progression", Ontology), ("tumor_grade", Ontology), ("procedure", Procedure)]:
             set_field(json, ret, field_name, type)
-
+        
         individual_age_at_collection = json.get("individual_age_at_collection")
         if individual_age_at_collection != None:
             if individual_age_at_collection.get("age") != None:
-                ret.individual_age_at_collection = Age(individual_age_at_collection.get("age"))
+                set_field(json, ret, 'individual_age_at_collection', Age)
             else:
-                ret.individual_age_at_collection = AgeRange(**individual_age_at_collection)
+                set_field(json, ret, 'individual_age_at_collection', AgeRange)
 
         set_extra_properties(json, ret)
         

--- a/api/schemas/katsu/phenopacket/disease.py
+++ b/api/schemas/katsu/phenopacket/disease.py
@@ -36,11 +36,11 @@ class Disease:
         onset = json.get("onset")
         if onset != None:
             if onset.get("age") != None:
-                ret.onset = Age(onset.get("age"))
+                set_field(json, ret, "onset", Age)
             elif onset.get("id") != None:
-                ret.onset = Ontology(**onset)
+                set_field(json, ret, "onset", Ontology)
             else:
-                ret.onset = AgeRange(**onset)
+                set_field(json, ret, "onset", AgeRange)
         
         for (field_name, type) in [("disease_stage", Ontology),("tnm_finding", Ontology)]:
             set_field_list(json, ret, field_name, type)

--- a/api/schemas/katsu/phenopacket/htsfile.py
+++ b/api/schemas/katsu/phenopacket/htsfile.py
@@ -14,13 +14,13 @@ class HtsFileInputType(Input):
 @strawberry.type
 class HtsFile:
     uri: str
-    description: str
     hts_format: str
     genome_assembly: str
-    individual_to_sample_identifiers: JSONScalar
-    extra_properties: JSONScalar
-    created: str
-    updated: str
+    description: Optional[str] = None
+    individual_to_sample_identifiers: Optional[JSONScalar] = None
+    extra_properties: Optional[JSONScalar] = None
+    created: Optional[str] = None
+    updated: Optional[str] = None
 
     @staticmethod
     def deserialize(json):

--- a/api/schemas/katsu/phenopacket/individual.py
+++ b/api/schemas/katsu/phenopacket/individual.py
@@ -51,9 +51,9 @@ class Individual:
         age = json.get("age")
         if age != None:
             if age.get("age") != None:
-                ret.age = Age(age.get("age"))
+                set_field(json, ret, 'age', Age)
             else:
-                ret.age = AgeRange(**age)
+                set_field(json, ret, 'age', AgeRange)
         
         for (field_name, type) in [("taxonomy", Ontology), ("comorbid_condition", ComorbidCondition),\
                                     ("ecog_performance_status", Ontology), ("karnofsky", Ontology)]:

--- a/api/schemas/katsu/phenopacket/phenopacket.py
+++ b/api/schemas/katsu/phenopacket/phenopacket.py
@@ -51,8 +51,9 @@ class Phenopacket:
 
     @strawberry.field
     async def candig_server_variants(self, info, input: Optional[CandigServerVariantInput] = None) -> List[CandigServerVariant]:
-        res = await info.context["candig_server_variants_loader"].load(CandigServerVariantDataLoaderInput(None, input, self.id, info))
-        return res
+        if self.subject is not None and self.subject.id is not None:
+            return await info.context["candig_server_variants_loader"].load(CandigServerVariantDataLoaderInput(None, input, self.subject.id, info))
+        return []
 
     @staticmethod
     def deserialize(json):

--- a/api/schemas/katsu/phenopacket/phenotypicfeature.py
+++ b/api/schemas/katsu/phenopacket/phenotypicfeature.py
@@ -1,4 +1,5 @@
 from api.interfaces.input import Input
+from api.schemas.json_formats.phenopacket_evidence import PhenopacketEvidence, PhenopacketEvidenceInputType
 from api.schemas.utils import generic_filter, set_extra_properties, set_field, set_field_list
 from typing import List, Optional
 import strawberry
@@ -14,7 +15,7 @@ class PhenotypicFeatureInputType(Input):
     severity: Optional[OntologyInputType] = None
     modifier: Optional[List[OntologyInputType]] = None
     onset: Optional[OntologyInputType] = None
-    evidence: Optional[OntologyInputType] = None
+    evidence: Optional[PhenopacketEvidenceInputType] = None
     biosample: Optional[str] = None
     phenopacket: Optional[str] = None
     
@@ -28,7 +29,7 @@ class PhenotypicFeature:
     severity: Optional[Ontology] = None
     modifier: Optional[List[Ontology]] = None
     onset: Optional[Ontology] = None
-    evidence: Optional[Ontology] = None
+    evidence: Optional[PhenopacketEvidence] = None
     biosample: Optional[str] = None
     phenopacket: Optional[str] = None
     extra_properties: Optional[JSONScalar] = None
@@ -40,7 +41,7 @@ class PhenotypicFeature:
         ret = PhenotypicFeature(**json)
 
         for (field_name ,type) in [("type", Ontology), ("severity", Ontology), \
-                                ("onset", Ontology), ("evidence", Ontology)]:
+                                ("onset", Ontology), ("evidence", PhenopacketEvidence)]:
             set_field(json, ret, field_name, type)
 
         set_field_list(json, ret, "modifier", Ontology)

--- a/api/schemas/utils.py
+++ b/api/schemas/utils.py
@@ -45,8 +45,13 @@ POST_VARIANT_SEARCH_BODY={
 
 def get_post_search_body(input, dataset_id, patient_id):
     body = POST_SEARCH_BODY.copy()
+    if patient_id is not None:
+        body["components"][0]["patients"]["filters"][0]["value"] = patient_id
+    else:
+        body["components"][0]["patients"]["filters"][0]["value"] = "N/A"
+        body["components"][0]["patients"]["filters"][0]["operator"] = "!="
+    
     body["datasetId"] = dataset_id
-    body["components"][0]["patients"]["filters"][0]["value"] = patient_id
     body["results"][0]["start"] = input.start
     body["results"][0]["end"] = input.end
     body["results"][0]["referenceName"] = input.referenceName

--- a/app.py
+++ b/app.py
@@ -5,14 +5,12 @@ from api.query import Query
 from starlette.responses import Response
 from starlette.websockets import WebSocket
 import strawberry
-from api.schemas.katsu.phenopacket.phenopacket import Phenopacket
-from typing import Optional, Union, Any
+from typing import Optional, Union
 from strawberry.asgi import GraphQL as BaseGraphQL
 from strawberry.dataloader import DataLoader
 from starlette.requests import Request
 from api.schema import schema
 from fastapi import FastAPI
-import sys
 
 class MyGraphQL(BaseGraphQL):
     async def get_context(


### PR DESCRIPTION
## Description
This PR deals with fixes to the GraphQL schema prior to the implementation of integration tests in the GraphQL-interface. There are mostly variable type changes that were noticed when using and testing the GraphQL-interface. Some additional changes were made to better accommodate filtering by dataset and patient id, where applicable. Overall, this PR is rather small, not dealing with any new work but rather cleaning up errors in the previous lines of work.

## Changelog
- Modified GraphQL Schemas to fix errors in deserialization
- Modified GraphQL Schemas to better filter by dataset id and patient id
- Fixed Errors in Deserialization
- Changed Variable Types to work with deserialization

## Dependencies
- N/A

## Testing
- There really isn't much to test here, we are simply updating some of the schema portions to fit the data fields returned by katsu and candig. If you really wanted to, you could choose to follow the data collection instructions in the GraphQL-interface's README/docs. Then you could run simple commands in GraphiQL, like those mentioned in the docs/README. 
- Given that this PR is in preparation for GraphQL Integration Testing, it may be easier to leave the testing alone at this point and allow the integration tests to work with these changes.