### PR TITLE
DIG-803: Adding Travis CI Integration to GraphQL-Interface Repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - node
 
-cache: 
+cache:
   directories:
     - ~/build/CanDIG/GraphQL-interface/node_modules
 
@@ -20,11 +20,11 @@ before_install:
   - docker --version
 
 install:
-  docker-compose -f tests/docker-compose.yaml up --detach
+  - docker-compose -f tests/docker-compose.yaml up --detach
 
 before_script:
   - npm install newman
-  ~/build/CanDIG/GraphQL-interface/node_modules/.bin/newman --version
+  - ~/build/CanDIG/GraphQL-interface/node_modules/.bin/newman --version
 
 script:
   - ~/build/CanDIG/GraphQL-interface/node_modules/.bin/newman run ./tests/postman/GraphQL-Interface-Integration-Tests.postman_collection.json -e ./tests/postman/GraphQL-Integration-Testing.postman_environment.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: node_js
+
+node_js:
+  - node
+
+cache: 
+  directories:
+    - ~/build/CanDIG/GraphQL-interface/node_modules
+
+addons:
+  apt:
+    packages:
+      - docker-ce
+
+services:
+  - docker
+
+before_install:
+  - npm root
+  - docker --version
+
+install:
+  docker-compose -f tests/docker-compose.yaml up --detach
+
+before_script:
+  - npm install newman
+  ~/build/CanDIG/GraphQL-interface/node_modules/.bin/newman --version
+
+script:
+  - ~/build/CanDIG/GraphQL-interface/node_modules/.bin/newman run ./tests/postman/GraphQL-Interface-Integration-Tests.postman_collection.json -e ./tests/postman/GraphQL-Integration-Testing.postman_environment.json

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 ## Purpose
 
-Proof-of-concept service built to display GraphQL integration with CanDIGv2 stack. For information on how to build the service locally, go to the [docs folder's README](docs/README.md). If you are building via the CanDIGv2 stack, follow the instructions present in the CanDIGv2 repo documentation.
+A proof-of-concept service built to display the integration of a GraphQL endpoint with the CanDIGv2 stack. For information on how to build the service locally, go to the [docs folder's README](docs/README.md). If you are building this via the CanDIGv2 stack, follow the instructions present in the CanDIGv2 repo documentation.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # GraphQL-interface
 
-Proof-of-concept service built to display GraphQL integration with CanDIGv2 stack. For information on how to build the service locally, go to the [docs README](docs/README.md). If building via the CanDIGv2 stack, follow the instructions present in said repository's documentation.
+## Status
+
+[![Build Status](https://app.travis-ci.com/CanDIG/GraphQL-interface.svg?branch=master)](https://app.travis-ci.com/CanDIG/GraphQL-interface)
+
+## Purpose
+
+Proof-of-concept service built to display GraphQL integration with CanDIGv2 stack. For information on how to build the service locally, go to the [docs folder's README](docs/README.md). If you are building via the CanDIGv2 stack, follow the instructions present in the CanDIGv2 repo documentation.

--- a/tests/postman/GraphQL-Interface-Integration-Tests.postman_collection.json
+++ b/tests/postman/GraphQL-Interface-Integration-Tests.postman_collection.json
@@ -1418,7 +1418,6 @@
 											"    pm.expect(variant2.getKatsuIndividuals.id).to.eql(patientId2)",
 											"",
 											"    for (const [field, value] of Object.entries(variant2.getKatsuIndividuals)) {",
-											"        console.log(value)",
 											"        if ((field != \"id\") && (field != \"karyotypicSex\") && (field != \"created\") && (field != \"updated\")) {",
 											"            pm.expect(value).to.eql(null)",
 											"        }",


### PR DESCRIPTION
## Description
This PR deals with the [DIG-803](https://candig.atlassian.net/browse/DIG-803) ticket, a child of the [DIG-799](https://candig.atlassian.net/browse/DIG-799) ticket focused on setting up the GraphQL-interface with Integration Testing. This PR in particular, deals with the integration of the GraphQL-interface with the Travis CI service, to allow for continuous integration testing of the GraphQL-interface. A simple Travis job is set up, which uses the `newman` CLI to run the integration tests created in Postman, as part of earlier tickets. The mock candig/katsu server, created earlier, is setup alongside an instance of the graphql interface using docker and run through Travis. On average, each build takes just over two minutes to run. The repo's README has also been modified to include the Travis 'Build Status', and some Postman Tests were also cleaned up to get rid of their console.logs.

## Changelog
- Added .travis.yml file to add Travis CI integration testing
- Modified README to fix typos and add Travis Status
- Modified a Postman Request

## Dependencies
- This PR depends on #16 

## Testing
- None required, Travis CI has automatically run checks on the repo.