### PR TITLE
DIG-782: Fixed GraphQL Filter

### DIFF
--- a/api/query.py
+++ b/api/query.py
@@ -20,8 +20,13 @@ class Query:
     async def candig_server_variants(self, info, input: Optional[CandigServerVariantInput], dataset_name: Optional[str] = None, dataset_id: Optional[str] = None) -> List[CandigServerVariant]:
         dataset_ids = (dataset_id,) if dataset_id is not None else None
         patient = input.katsu_individual if input is not None  else None
-        patient_id = patient.ids if patient is not None else None
-        return await info.context["candig_server_variants_loader"].load(CandigServerVariantDataLoaderInput(dataset_ids, input, patient_id, info))
+        patient_ids = patient.ids if patient is not None else [None]
+
+        ret = []
+        for patient_id in patient_ids:
+            ret.extend(await info.context["candig_server_variants_loader"].load(CandigServerVariantDataLoaderInput(dataset_ids, input, patient_id, info)))
+        
+        return ret
 
     @strawberry.field
     async def aggregate(self, info) -> AggregateQuery:

--- a/api/schemas/katsu/mcode/mcode_packet.py
+++ b/api/schemas/katsu/mcode/mcode_packet.py
@@ -23,7 +23,7 @@ class MCodePacketInputType(Input):
     medication_statement: Optional[List[MedicationStatementInputType]] = None
     date_of_death: Optional[str] = None
     cancer_disease_status: Optional[OntologyInputType] = None
-    tanle: Optional[str] = None
+    table: Optional[str] = None
 
 
 @strawberry.type

--- a/api/schemas/katsu/phenopacket/individual.py
+++ b/api/schemas/katsu/phenopacket/individual.py
@@ -10,7 +10,7 @@ from api.schemas.katsu.phenopacket.biosample import Biosample
 
 @strawberry.input
 class IndividualInputType(Input):
-    ids: Optional[strawberry.ID] = None
+    ids: Optional[List[strawberry.ID]] = None
     date_of_birth: Optional[str] = None
     sex: Optional[str] = None
     karyotypic_sex: Optional[str] = None

--- a/api/schemas/utils.py
+++ b/api/schemas/utils.py
@@ -167,7 +167,7 @@ def generic_filter(instance, input):
         attr_input_value = input.__getattribute__(attr)
         if attr_input_value != None:
             if attr == "ids" and "alternate_ids" in instance.__dir__():
-                if not any(id == instance.id or id in instance.alternate_ids for id in attr):
+                if not any(id == instance.id or id in instance.alternate_ids for id in attr_input_value):
                     return False
                 continue
             if attr == "ids":

--- a/tests/postman/GraphQL-Interface-Integration-Tests.postman_collection.json
+++ b/tests/postman/GraphQL-Interface-Integration-Tests.postman_collection.json
@@ -1472,7 +1472,7 @@
 								"body": {
 									"mode": "graphql",
 									"graphql": {
-										"query": "query test_candig_success_4($variantStart: String, $variantEnd: String, $variantRef: String, $datasetId: String, $patient: ID) {\n    candigServerVariants(\n        datasetId: $datasetId, \n        input: {\n            start: $variantStart,\n            end: $variantEnd,\n            referenceName: $variantRef,\n            katsuIndividual: {\n                ids: $patient\n            }\n        }) {\n        id\n    }\n}",
+										"query": "query test_candig_success_4($variantStart: String, $variantEnd: String, $variantRef: String, $datasetId: String, $patient: ID!) {\n    candigServerVariants(\n        datasetId: $datasetId, \n        input: {\n            start: $variantStart,\n            end: $variantEnd,\n            referenceName: $variantRef,\n            katsuIndividual: {\n                ids: [$patient]\n            }\n        }) {\n        id\n    }\n}",
 										"variables": "{\n    \"variantStart\": \"{{variantStart1}}\",\n    \"variantEnd\": \"{{variantEnd1}}\",\n    \"variantRef\": \"{{variantRef1}}\",\n    \"datasetId\": \"{{datasetId1}}\",\n    \"patient\": \"{{patient2}}\"\n}"
 									}
 								},
@@ -1509,7 +1509,7 @@
 								"body": {
 									"mode": "graphql",
 									"graphql": {
-										"query": "query test_candig_success_5($variantStart: String, $variantEnd: String, $variantRef: String, $datasetId: String, $patient: ID){\n    candigServerVariants(\n        datasetId: $datasetId, \n        input: {\n            start: $variantStart,\n            end: $variantEnd,\n            referenceName: $variantRef\n            katsuIndividual: {\n                ids: $patient\n            }\n        }) {\n        id\n    }\n}",
+										"query": "query test_candig_success_5($variantStart: String, $variantEnd: String, $variantRef: String, $datasetId: String, $patient: ID!){\n    candigServerVariants(\n        datasetId: $datasetId, \n        input: {\n            start: $variantStart,\n            end: $variantEnd,\n            referenceName: $variantRef\n            katsuIndividual: {\n                ids: [$patient]\n            }\n        }) {\n        id\n    }\n}",
 										"variables": "{\n    \"variantStart\": \"{{variantStart1}}\",\n    \"variantEnd\": \"{{variantEnd1}}\",\n    \"variantRef\": \"{{variantRef1}}\",\n    \"datasetId\": \"{{datasetId1}}\",\n    \"patient\": \"None\"\n}"
 									}
 								},
@@ -1659,7 +1659,7 @@
 								"body": {
 									"mode": "graphql",
 									"graphql": {
-										"query": "query test_candig_error_2($datasetId: String, $patient: ID) {\n    candigServerVariants(\n        datasetId: $datasetId, \n        input: {\n            katsuIndividual: {\n                ids: $patient\n            }\n        }) {\n        id\n    }\n}",
+										"query": "query test_candig_error_2($datasetId: String, $patient: ID!) {\n    candigServerVariants(\n        datasetId: $datasetId, \n        input: {\n            katsuIndividual: {\n                ids: [$patient]\n            }\n        }) {\n        id\n    }\n}",
 										"variables": "{\n    \"datasetId\": \"{{datasetId1}}\",\n    \"patient\": \"{{patient2}}\"\n}"
 									}
 								},
@@ -1700,7 +1700,7 @@
 								"body": {
 									"mode": "graphql",
 									"graphql": {
-										"query": "query test_candig_error_3($datasetId: String, $variantStart: String, $variantEnd: String, $variantRef: String, $patient: ID) {\n    candigServerVariants(\n        datasetId: $datasetId, \n        input: {\n            start: $variantStart,\n            end: $variantEnd,\n            referenceName: $variantRef,\n            katsuIndividual: {\n                ids: $patient\n            }\n        }) {\n        id\n    }\n}",
+										"query": "query test_candig_error_3($datasetId: String, $variantStart: String, $variantEnd: String, $variantRef: String, $patient: ID!) {\n    candigServerVariants(\n        datasetId: $datasetId, \n        input: {\n            start: $variantStart,\n            end: $variantEnd,\n            referenceName: $variantRef,\n            katsuIndividual: {\n                ids: [$patient]\n            }\n        }) {\n        id\n    }\n}",
 										"variables": "{\n    \"datasetId\": \"Wrong\",\n    \"variantStart\": \"{{variantStart1}}\",\n    \"variantEnd\": \"{{variantEnd1}}\",\n    \"variantRef\": \"{{variantRef1}}\",\n    \"patient\": \"{{patient2}}\"\n}"
 									}
 								},


### PR DESCRIPTION
## Description
This PR is associated with the [DIG-782](https://candig.atlassian.net/browse/DIG-782) ticket, a child of the [DIG-774](https://candig.atlassian.net/browse/DIG-774) ticket. The latter ticket is a story aiming to federate the Synthea classifier created in earlier tickets. The former is a sub-ticket that aims to split the corpus collected into several datasets. In order to split the corpus, we must filter the graphql query by the unique table_id, given that each site will have its own table_id. This ticket fixes the filter in the GraphQL interface by correcting typos and missing field types. It also modifies the tests accordingly to use the typo-corrected fields. This will allow us to split the corpus in the federated-learning repo by table_id.

## Changelog
- Fixed field & type typos to enable proper filtering
- Corrected tests to fit new typo-corrected schema
- Corrected candig service to search by multiple patient ids using corrected schema
- Fixed Filter to filter by alternate Ids correctly

## Dependencies
- N/A

## Testing
- None Required: Travis CI has already tested and ensured integration with existing code