### PR TITLE
HOTFIX: Fixed Travis Node Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - node
+  - 17
 
 cache:
   directories:


### PR DESCRIPTION
## Description
This PR fixes the Travis CI issues arising from the recent release of node v18.0.0.

## Changelog
- Set `node_js` version to `17`, instead of `node` which would fetch the latest node version

## Dependencies
- N/A

## Testing
- N/A